### PR TITLE
feat: base_url added to the generate and embed docs when openai is the specified engine

### DIFF
--- a/functions/embed.mdx
+++ b/functions/embed.mdx
@@ -139,7 +139,7 @@ SELECT
         input := 'Once upon a time in a faraway land',
         model := 'your_model_name',
         base_url := 'your_base_url', -- Only applicable when the engine is 'openai'
-        token := 'your_token' -- Optional, depending on the base_url requirements
+        token := 'your_token' 
     ) AS text_embedding
 ```
 On execution, we get: 

--- a/functions/embed.mdx
+++ b/functions/embed.mdx
@@ -129,24 +129,6 @@ On execution, we get:
 
 <Note>Please note that you would need to create an API key from OpenAI.</Note>
 
-### Standalone Usage
-Here is an example of how to use the `embed` function as a standalone query:
-```sql
-SELECT 
-    thanosql.embed(
-        engine := 'huggingface',
-        input := 'Once upon a time in a faraway land',
-        model := 'openai/clip-vit-base-patch32',
-        model_args := '{"device_map": "cpu"}'
-    ) AS text_embedding
-```
-On execution, we get: 
-```
-| text_embedding                         |
-|----------------------------------------|
-| [0.012345, -0.023456, ... , -0.034567] |
-```
-
 ## Using the OpenAI Client 
 Here is an example of how to use the `embed` function with the base URL using the OpenAI Client:
 
@@ -166,6 +148,26 @@ On execution, we get:
 |----------------------------------------|
 | [0.014321, -0.021234, ... , -0.042567] |
 ```
+
+### Standalone Usage
+Here is an example of how to use the `embed` function as a standalone query:
+```sql
+SELECT 
+    thanosql.embed(
+        engine := 'huggingface',
+        input := 'Once upon a time in a faraway land',
+        model := 'openai/clip-vit-base-patch32',
+        model_args := '{"device_map": "cpu"}'
+    ) AS text_embedding
+```
+On execution, we get: 
+```
+| text_embedding                         |
+|----------------------------------------|
+| [0.012345, -0.023456, ... , -0.034567] |
+```
+
+
 
 ## Model Restrictions
 <Warning>

--- a/functions/embed.mdx
+++ b/functions/embed.mdx
@@ -16,7 +16,8 @@ SELECT
         model := 'model_name',
         model_args := 'model_args_in_json',
         tokenizer_args := 'tokenizer_args_in_json',
-        token := 'auth_token'
+        token := 'auth_token',
+        base_url := 'base_url' -- Only applicable when the engine is 'openai'
     ) AS embedding
 FROM 
     table_name
@@ -32,6 +33,7 @@ FROM
 | `model_args`    | json   | `None`           | JSON string representing additional arguments for the model.                                          | N/A                          |
 | `tokenizer_args`| json   | `None`           | JSON string representing additional arguments for the tokenizer.                                      | N/A                                                                                                        |
 | `token`         | string | `None`           | Token for authentication if required by the model.                                                    | N/A                                                                                                        |
+| `base_url`     | string | `None`           | Base URL to point the client to a different endpoint than the default OpenAI API endpoint. This is only applicable when the engine is `openai`.  | N/A                                                                                                        |
 
 
 ## Returns
@@ -145,8 +147,29 @@ On execution, we get:
 | [0.012345, -0.023456, ... , -0.034567] |
 ```
 
+## Using the OpenAI Client 
+Here is an example of how to use the `embed` function with the base URL using the OpenAI Client:
+
+```sql
+SELECT 
+    thanosql.embed(
+        engine := 'openai',
+        input := 'Once upon a time in a faraway land',
+        model := 'your_model_name',
+        base_url := 'your_base_url', -- Only applicable when the engine is 'openai'
+        token := 'your_token' -- Optional, depending on the base_url requirements
+    ) AS text_embedding
+```
+On execution, we get: 
+```
+| text_embedding                         |
+|----------------------------------------|
+| [0.014321, -0.021234, ... , -0.042567] |
+```
 
 ## Model Restrictions
 <Warning>
 When using the `embed` function with the `huggingface` engine, ensure that only models compatible with the HuggingFace AutoModel and AutoTokenizer are used. Verify that the selected model is supported by the HuggingFace library to avoid compatibility issues. Even with compatible models, some models might still not work. We are actively working on improving compatibility and functionality to provide a better user experience. For more information, refer to the official [Hugging Face documentation](https://huggingface.co/docs/transformers/en/model_doc/auto).
 </Warning>
+
+

--- a/functions/generate.mdx
+++ b/functions/generate.mdx
@@ -141,7 +141,7 @@ SELECT
         input := 'Once upon a time in a faraway land',
         model := 'your_model_name',
         base_url := 'your_base_url', -- Only applicable when the engine is 'openai'
-        token := 'your_token' -- Optional, depending on the base_url requirements
+        token := 'your_token'
     ) AS generated_text
 ```
 On execution, we get: 

--- a/functions/generate.mdx
+++ b/functions/generate.mdx
@@ -131,6 +131,26 @@ On execution, we get:
 Please note that you would need to create an API key from OpenAI. For more information, check out the official [OpenAI documentation](https://platform.openai.com/docs/api-reference/introduction).
 </Note>
 
+## Using the OpenAI Client 
+Here is an example of how to use the `generate` function with the base URL using the OpenAI Client:
+
+```sql
+SELECT 
+    thanosql.generate(
+        engine := 'openai',
+        input := 'Once upon a time in a faraway land',
+        model := 'your_model_name',
+        base_url := 'your_base_url', -- Only applicable when the engine is 'openai'
+        token := 'your_token' -- Optional, depending on the base_url requirements
+    ) AS generated_text
+```
+On execution, we get: 
+```
+| generated_text                                                                 |
+|-------------------------------------------------------------------------------|
+| Once upon a time in a faraway land, there lived a wise old king who...        |
+```
+
 
 ### Standalone Usage
 Here is an example of how to use the generate function as a standalone query:
@@ -152,25 +172,6 @@ On execution, we get:
 | Once upon a time in a faraway land, there lived a wise old owl who had seen many seasons come and go...  |
 ```
 
-## Using the OpenAI Client 
-Here is an example of how to use the `generate` function with the base URL using the OpenAI Client:
-
-```sql
-SELECT 
-    thanosql.generate(
-        engine := 'openai',
-        input := 'Once upon a time in a faraway land',
-        model := 'your_model_name',
-        base_url := 'your_base_url', -- Only applicable when the engine is 'openai'
-        token := 'your_token' -- Optional, depending on the base_url requirements
-    ) AS generated_text
-```
-On execution, we get: 
-```
-| generated_text                                                                 |
-|-------------------------------------------------------------------------------|
-| Once upon a time in a faraway land, there lived a wise old king who...        |
-```
 
 ## Model Restrictions
 <Warning>

--- a/functions/generate.mdx
+++ b/functions/generate.mdx
@@ -15,7 +15,8 @@ SELECT
         input := [column_name | 'input_text'],
         model := 'model_name',
         model_args := 'model_args_in_json',
-        token := 'auth_token'
+        token := 'auth_token',
+        base_url := 'base_url' -- Only applicable when the engine is 'openai'
     ) AS generated_text
 FROM 
     table_name
@@ -30,6 +31,7 @@ FROM
 | `model`     | string |                  | The name or path of the pre-trained text generation model.                                            | Example: `'meta-llama/Meta-Llama-3-8B'`                                                                    |
 | `model_args`| json   | `None`           | JSON string representing additional arguments for the model.                                          | Example: `'{"max_new_tokens": 50}'` Common Parameters: `max_new_tokens`, `temperature`, `top_p`, `top_k` |
 | `token`     | string | `None`           | Token for authentication if required by the model.                                                    | N/A                                                                                                        |
+| `base_url`     | string | `None`           | Base URL to point the client to a different endpoint than the default OpenAI API endpoint. This is only applicable when the engine is `openai`.  | N/A                                                                                                        |
 
 
 ## Returns
@@ -150,6 +152,25 @@ On execution, we get:
 | Once upon a time in a faraway land, there lived a wise old owl who had seen many seasons come and go...  |
 ```
 
+## Using the OpenAI Client 
+Here is an example of how to use the `generate` function with the base URL using the OpenAI Client:
+
+```sql
+SELECT 
+    thanosql.generate(
+        engine := 'openai',
+        input := 'Once upon a time in a faraway land',
+        model := 'your_model_name',
+        base_url := 'your_base_url', -- Only applicable when the engine is 'openai'
+        token := 'your_token' -- Optional, depending on the base_url requirements
+    ) AS generated_text
+```
+On execution, we get: 
+```
+| generated_text                                                                 |
+|-------------------------------------------------------------------------------|
+| Once upon a time in a faraway land, there lived a wise old king who...        |
+```
 
 ## Model Restrictions
 <Warning>


### PR DESCRIPTION
Refer to: https://github.com/smartmind-team/thanosql/pull/10